### PR TITLE
P2 explore pages unit tests

### DIFF
--- a/back-end/package.json
+++ b/back-end/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-  "test": "mocha test/explore.test.js --timeout 5000",
-  "coverage": "c8 mocha test/explore.test.js --timeout 5000",
+  "test": "mocha \"test/**/*.test.js\" --timeout 5000",
+  "coverage": "c8 mocha \"test/**/*.test.js\" --timeout 5000",
   "start": "node ./server",
   "dev": "nodemon ./server"
 },

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -4,10 +4,11 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node ./server",
-    "dev": "nodemon ./server"
-  },
+  "test": "mocha test/explore.test.js --timeout 5000",
+  "coverage": "c8 mocha test/explore.test.js --timeout 5000",
+  "start": "node ./server",
+  "dev": "nodemon ./server"
+},
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -19,6 +20,10 @@
     "mongoose": "^9.3.0"
   },
   "devDependencies": {
+    "c8": "^11.0.0",
+    "chai": "^6.2.2",
+    "chai-http": "^5.1.2",
+    "mocha": "^11.7.5",
     "nodemon": "^3.1.14"
   }
 }

--- a/back-end/test/explore.test.js
+++ b/back-end/test/explore.test.js
@@ -66,3 +66,26 @@ describe("PlayerPlaytest", () => {
     expect(res.body).to.have.property("error");
   });
 });
+
+// projectdetails
+describe("ProjectDetails", () => {
+  it("GET /explore/projects/:id with unknown id → 404", async () => {
+    const res = await request.execute(app).get("/explore/projects/99999999");
+    expect(res).to.have.status(404);
+    expect(res.body).to.have.property("error");
+  });
+
+  it("GET /explore/projects/:id with valid id → 200 and project object", async () => {
+    const listRes = await request.execute(app).get("/explore/projects");
+    expect(listRes).to.have.status(200);
+
+    if (listRes.body.length === 0) return;
+
+    const firstId = listRes.body[0].id;
+    const res = await request.execute(app).get(`/explore/projects/${firstId}`);
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an("object");
+    expect(res.body).to.have.property("id", firstId);
+    expect(res.body).to.have.property("title");
+  });
+});

--- a/back-end/test/explore.test.js
+++ b/back-end/test/explore.test.js
@@ -39,3 +39,30 @@ describe("PlayerExplore", () => {
     expect(res.body).to.have.property("error");
   });
 });
+
+//playtest
+describe("PlayerPlaytest", () => {
+  it("GET /playtests → 200 and returns an array", async () => {
+    const res = await request.execute(app).get("/playtests");
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an("array");
+  });
+
+  it("GET /feedback/:projectId → 200 and returns an array", async () => {
+    const res = await request.execute(app).get("/feedback/1");
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an("array");
+  });
+
+  it("GET /feedback/:projectId with unknown id → 200 and empty array", async () => {
+    const res = await request.execute(app).get("/feedback/99999999");
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an("array").that.is.empty;
+  });
+
+  it("DELETE /playtests/:projectId with unknown id → 404", async () => {
+    const res = await request.execute(app).delete("/playtests/99999999");
+    expect(res).to.have.status(404);
+    expect(res.body).to.have.property("error");
+  });
+});

--- a/back-end/test/explore.test.js
+++ b/back-end/test/explore.test.js
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import chaiHttp, { request } from "chai-http";
+import { use } from "chai";
+import app from "../app.js";
+
+use(chaiHttp);
+
+// playerexplore
+describe("PlayerExplore", () => {
+  it("GET /explore/projects → 200 and returns an array", async () => {
+    const res = await request.execute(app).get("/explore/projects");
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an("array");
+  });
+
+  it("GET /explore/projects → only published or public projects are returned", async () => {
+    const res = await request.execute(app).get("/explore/projects");
+    expect(res).to.have.status(200);
+    res.body.forEach((p) => {
+      expect(["published", "public"]).to.include(p.visibility);
+    });
+  });
+
+  it("GET /playtests → 200 and returns an array", async () => {
+    const res = await request.execute(app).get("/playtests");
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an("array");
+  });
+
+  it("POST /playtests without projectId → 400 bad request", async () => {
+    const res = await request.execute(app).post("/playtests").send({});
+    expect(res).to.have.status(400);
+    expect(res.body).to.have.property("error");
+  });
+
+  it("POST /playtests with non-existent projectId → 404", async () => {
+    const res = await request.execute(app).post("/playtests").send({ projectId: 99999999 });
+    expect(res).to.have.status(404);
+    expect(res.body).to.have.property("error");
+  });
+});


### PR DESCRIPTION
Setup mocha, chai, and c8 for unit tests

p2 unit tests covers 
- GET /explore/projects (PlayerExplore)
- GET /playtests (PlayerExplore, PlayerPlaytest)
- POST /playtests (PlayerExplore)
- GET /feedback/:projectId (PlayerPlaytest)
- DELETE /playtests/:projectId (PlayerPlaytest)
- GET /explore/projects/:id (ProjectDetails)
- modified package.json for npm test and npm run coverage